### PR TITLE
Fix defect of incorrect use start() method in readme and decorator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,22 +63,10 @@ This is the way to make more robust actions, and function-based actions are auto
 class Talker(planner.SimpleAction):
   name = "talk"
   
-  def start(arguments):
+  def _start(arguments):
     check_preconditions()
     say_stuff()
     set_effects()
-    
-  def cancel():
-    shut_up()
-    tear_down()
-    
-  def pause():
-    self.interupted = True
-    shut_up()
-    
-  def resume():
-    # arguments are additionally stored as `self.arguments`
-    self.start(self.arguments)
 ```
 
 That's it! The relevant code will be called as ROSPlan dispatches it (so long as you called the initializer in the beginning)
@@ -91,7 +79,7 @@ A special class that could receive for multiple actions exists, it is the `Actio
 class Listener(planner.ActionSink):
   name = ["talker_1", "talker_2"]
   
-  def start(self, action_name, arguments):
+  def _start(self, action_name, arguments):
     say_stuff()
 ```
 

--- a/examples/register_actions.py
+++ b/examples/register_actions.py
@@ -9,14 +9,14 @@ from rosplan_pytools.interfaces.action_interface import *
 class DemoSimpleAction(SimpleAction):
     name = "demo1"
 
-    def start(self, **kwargs):
+    def _start(self, **kwargs):
         print("Demo 1!!!")
 
 
 class DemoActionWithEffects(Action):
     name = "demo3"
 
-    def start(self, **kwargs):
+    def _start(self, **kwargs):
         print("Demo 3!!!")
         return True
 
@@ -24,7 +24,7 @@ class DemoActionWithEffects(Action):
 class DemoMultipleActions(ActionSink):
     name = ["demo2a", "demo2b"]
 
-    def start(self, action_name, **kwargs):
+    def _start(self, action_name, **kwargs):
         print("Tracer: %s --> %s" % (DemoMultipleActions.name, action_name))
         return True
 

--- a/src/rosplan_pytools/interfaces/action_interface.py
+++ b/src/rosplan_pytools/interfaces/action_interface.py
@@ -97,6 +97,7 @@ def _action_receiver(msg):
 
 
 def register_action(name, action):
+
     global registered_actions
 
     if isinstance(name, str):
@@ -109,6 +110,7 @@ def register_action(name, action):
 def initialize_actions(auto_register_actions=True):
 
     global _list_actions
+
     if auto_register_actions:
         _list_actions = _list_existing_actions
     else:
@@ -122,6 +124,7 @@ def start_actions(dispatch_topic_name=None,
                   is_blocked=False):
 
     global feedback
+
     feedback_topic_name = feedback_topic_name or DEFAULT_FEEDBACK_TOPIC_NAME
     feedback = rospy.Publisher(feedback_topic_name, ActionFeedback, queue_size=10)
     dispatch_topic_name = dispatch_topic_name or DEFAULT_DISPATCH_TOPIC_NAME
@@ -488,7 +491,7 @@ def planner_simple_action(action_name):
             name = action_name.lower()  # Lowercase due to ROSPlan quirks
             _spec = inspect.getargspec(func)
 
-            def start(self, duration=0, **kwargs):
+            def _start(self, duration=0, **kwargs):
                 # Check whether function supports a timeout
                 if "duration" in self._spec.args or self._spec.keywords:
                     func(duration, **kwargs)


### PR DESCRIPTION
The method to be overwritten in an action is '_start()' instead of 'start()' as it is a protected method, fixed README information, examples, and action decorator. See #11.